### PR TITLE
Allow out of tree builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,10 +181,10 @@ endif
 # Qualcomm-specific code - start
 ifeq ($(ARCH),arm)
 ifeq ($(QUIC_ARM_BAREMETAL),yes)
-obj/crt/crt1.o : qualcomm-software/crt/arm/crt1_baremetal.s
+obj/crt/crt1.o : $(srcdir)/qualcomm-software/crt/arm/crt1_baremetal.s
 	$(AS_CMD)
 
-obj/crt/crt1_linux.o: qualcomm-software/crt/arm/crt1_linux.s
+obj/crt/crt1_linux.o: $(srcdir)/qualcomm-software/crt/arm/crt1_linux.s
 	$(AS_CMD)
 
 CRT_OBJS += obj/crt/crt1_linux.o

--- a/configure
+++ b/configure
@@ -862,5 +862,8 @@ test "x$pic_default" = xyes && echo 'AOBJS = $(LOBJS)'
 exec 1>&3 3>&-
 
 test "$srcdir" = "." || ln -sf $srcdir/Makefile .
+# Qualcomm-specific code start
+test "$srcdir" = "." || ln -sf $srcdir/build_variants.mk .
+# Qualcomm-specific code end
 
 printf "done\n"


### PR DESCRIPTION
Upstream musl (even the version musl-embedded is based on) seems to allow for out of tree builds. I think enabling this for musl-embedded is pretty straightforward--just making sure that we make paths source-relative and symlink our makefiles similar to what upstream does.

This is primarly helpful for us in that it lets us build multiple variants without worrying about whether they are concurrent.